### PR TITLE
Import mnemonic as primary in onboarding

### DIFF
--- a/Components/Sources/Import/BEIP20/ImportHDWalletView.swift
+++ b/Components/Sources/Import/BEIP20/ImportHDWalletView.swift
@@ -4,6 +4,9 @@ import Commons
 import UIComponents
 
 public struct ImportHDWalletView: View {
+    
+    private let primary: Bool
+    
     @State
     private var text = ""
 
@@ -13,7 +16,9 @@ public struct ImportHDWalletView: View {
     @Environment(\.presentationMode)
     var presentationMode
 
-    public init() { }
+    public init(primary: Bool = true) {
+        self.primary = primary
+    }
 
     public var body: some View {
         VStack(spacing: 0) {
@@ -74,7 +79,7 @@ public struct ImportHDWalletView: View {
 
     var importButton: some View {
         Button {
-            viewModel.importKey(with: text)
+            viewModel.importKey(with: text, primary: self.primary)
         } label: {
             HStack(spacing: 10) {
                 Image(systemName: "square.and.arrow.down")

--- a/Components/Sources/Import/BEIP20/ImportHDWalletViewModel.swift
+++ b/Components/Sources/Import/BEIP20/ImportHDWalletViewModel.swift
@@ -19,10 +19,10 @@ class ImportHDWalletViewModel: ObservableObject {
         self.importWallet = importWallet
     }
 
-    func importKey(with mnemonic: String) {
+    func importKey(with mnemonic: String, primary: Bool = true) {
         do {
             let seedPhrase = sanitize(wallet: mnemonic)
-            try importWallet.import(seedPhrase.bytes(), type: .mnemonic)
+            try importWallet.import(seedPhrase.bytes(), type: primary ? .primaryMnemonic : .mnemonic)
             AppOrchestra.home()
         } catch {
             print(error)

--- a/Components/Sources/Import/List/ImportView.swift
+++ b/Components/Sources/Import/List/ImportView.swift
@@ -4,11 +4,15 @@ import Commons
 import UIComponents
 
 public struct ImportView: View {
+    
+    private let primary: Bool
 
     @Environment(\.presentationMode)
     var presentationMode
 
-    public init() { }
+    public init(primary: Bool = false) {
+        self.primary = primary
+    }
 
     public var body: some View {
         NavigationView {
@@ -21,7 +25,7 @@ public struct ImportView: View {
                     Spacer()
                 }.padding(.top, 23)
                 VStack {
-                    NavigationLink(destination: ImportHDWalletView()) {
+                    NavigationLink(destination: ImportHDWalletView(primary: self.primary)) {
                         ImportViewCategoryItem(icon: ["SeedPhraseIcon"], title: "With Recovery Phrase", description: "Import wallets with a 12 word recovery phrase")
                     }
                     NavigationLink(destination: ImportPrivateKeyView()) {

--- a/Components/Sources/Onboarding/view/OnboardingView.swift
+++ b/Components/Sources/Onboarding/view/OnboardingView.swift
@@ -42,7 +42,7 @@ extension OnboardingView {
 
     func loginActions() {
         loginView.importWalletAction = {
-            let importView = ImportView()
+            let importView = ImportView(primary: true)
             self.present(UIHostingController(rootView: importView), animated: true)
         }
         loginView.createWalletAction = {


### PR DESCRIPTION
As a user coming from MetaMask I assume that when I import a mnemonic and then try to get my second account that it is derived from the imported mnemonic. Instead the app generated a new mnemonic and used that to derive accounts.

<details>
<summary>Before (click to see a video)</summary>

I was expecting the second address to be `0x70997970C51812dc3A010C7d01b50e0d17dc79C8`

https://user-images.githubusercontent.com/8790386/200383698-65ad4eec-7024-4536-ae72-9bac8438d8ef.MP4

</details>

<details>
<summary>After (click to see a video)</summary>

https://user-images.githubusercontent.com/8790386/200383805-255c531f-6fd5-4236-a365-a7ef6b9b2427.MP4 

</details>

The mnemonic I used for testing is `test test test test test test test test test test test junk`. The first 5 accounts are:

<img width="541" alt="addresses" src="https://user-images.githubusercontent.com/8790386/200385166-a3b48ba4-b9dc-45a4-9663-748a029eb027.png">

<sub><i>I tried to use a table but GitHub didn't embed the videos 🤷‍♂️</i></sub>