### PR TITLE
Add a `min-width` to popup

### DIFF
--- a/Extension/popup/src/pages/index.tsx
+++ b/Extension/popup/src/pages/index.tsx
@@ -190,7 +190,7 @@ export default function Home() {
   }, [shadowChainIdOption]);
 
   return (
-    <div className="flex justify-center">
+    <div className="flex justify-center" style={{ minWidth: 320 }}>
       <div className="w-full max-w-lg">
         <BlockHeader className="ml-1.5 font-semibold">
           <div className="">

--- a/Extension/popup/src/pages/index.tsx
+++ b/Extension/popup/src/pages/index.tsx
@@ -190,7 +190,7 @@ export default function Home() {
   }, [shadowChainIdOption]);
 
   return (
-    <div className="flex justify-center" style={{ minWidth: 320 }}>
+    <div className="flex justify-center min-w-[320px]">
       <div className="w-full max-w-lg">
         <BlockHeader className="ml-1.5 font-semibold">
           <div className="">


### PR DESCRIPTION
Quick win when running the app on macOS/iPadOS. Let me know if there's a more preferred styling approach. 320 is the width of the iPod touch 7th generation (the smallest iOS device that supports iOS 15).
|Before|After|
|-|-|
|![Simulator Screen Shot - iPad mini (6th generation) - 2022-11-10 at 22 31 10](https://user-images.githubusercontent.com/8790386/201199726-c97588ac-f2b2-4857-9cf1-a636f7b10e31.png)|![Simulator Screen Shot - iPad mini (6th generation) - 2022-11-10 at 22 25 22](https://user-images.githubusercontent.com/8790386/201199391-1060a89e-a7a4-496f-a9b4-3dc4f9cb1762.png)|
|<img width="1436" alt="image" src="https://user-images.githubusercontent.com/8790386/201199766-4f5c173d-2aaf-438f-a2b3-95a97cd07764.png">|<img width="1436" alt="image" src="https://user-images.githubusercontent.com/8790386/201199272-a9921a76-a0b9-4e8d-97b2-00a06b3ffe51.png">|
